### PR TITLE
speedup race tests

### DIFF
--- a/go.test.sh
+++ b/go.test.sh
@@ -3,7 +3,7 @@
 set -e
 echo "" > coverage.txt
 
-for d in $(go list ./... | grep -v vendor | grep -v test/e2e); do
+for d in $(go list -f '{{if .TestGoFiles}}{{ .ImportPath }}{{end}}' ./... | grep -v vendor | grep -v test/e2e); do
     go test -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt


### PR DESCRIPTION
use formatted `go list` command to compile and test Go packages that contain test files
Go compiler is very slow when it compiles a package with `race` flag. This change avoids compiling packages without tests.