### PR TITLE
Add Github release support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
-
+.DS_Store
 
 workflow-controller
 .vscode

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,24 @@
+project_name: workflow-controller
+release:
+  github:
+    owner: sdminonne
+    name: workflow-controller
+builds:
+- goos:
+  - linux
+  goarch:
+  - amd64
+  main: .
+  ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+  binary: workflow-controller
+dockers:
+  - image: workflowcontroller/workflow-controller
+    goos: linux
+    goarch: amd64
+    goarm: ''
+    binary: workflow-controller
+    latest: true
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,66 @@
 language: go
-os: linux
+dist: trusty
 sudo: required
-services:
-  - docker
 go:
-  - 1.8.3
+- 1.9.x
+os: linux
+services:
+- docker
+env:
+  global:
+  - CHANGE_MINIKUBE_NONE_USER=true
+  - TAG=${TRAVIS_TAG:=${TRAVIS_COMMIT}}
+  - GH_URL=https://sdminonne.github.io/workflow-controller
+  - IMAGE_NAME=traviscontroller
 go_import_path: github.com/sdminonne/workflow-controller
+before_install:
+- sudo apt-get -qq update
+- sudo apt-get install -y socat
+- docker run --rm jpetazzo/nsenter cat /nsenter > /tmp/nsenter && chmod +x /tmp/nsenter
+- sudo cp /tmp/nsenter /usr/local/bin
 install:
-  - curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-  - mkdir -p .bin; mv ./kubectl .bin/kubectl && chmod +x .bin/kubectl
-  - export PATH="$TRAVIS_BUILD_DIR/.bin:$PATH"
-  - wget https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.7.sh && chmod +x dind-cluster-v1.7.sh && ./dind-cluster-v1.7.sh up
-  - export PATH="$HOME/.kubeadm-dind-cluster:$PATH"
-  - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-  - kubectl -n kube-system create sa tiller
-  - kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-  - helm init --service-account tiller
-
-script:
-  - make build
-  - make test
-  - make container
-  - helm install --version latest -n end2end-test charts/workflow-controller --set image.pullPolicy=IfNotPresent
-  - while [ $(kubectl get pod --selector=app=workflow-controller --all-namespaces | grep 'workflow-controller' | awk '{print $4}') != "Running" ]; do echo "$(kubectl get pod --selector=app=workflow-controller --all-namespaces)"; sleep 5; done
-  - cd ./test/e2e && go test -c && ./e2e.test --kubeconfig=$HOME/.kube/config --ginkgo.slowSpecThreshold 30
-  - helm delete end2end-test
+- ./hack/ci-minikube-install.sh
+- minikube docker-env
+- kubectl get nodes
+- kubectl get pods --all-namespaces
+- curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+- kubectl -n kube-system create sa tiller
+- kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+- helm init --service-account tiller
+stages:
+- name: build
+- name: release
+  if: tag IS present
+jobs:
+  include:
+  - stage: build
+    name: build
+    script:
+    - make build
+    - make test
+    - make TAG=$TAG container
+    - docker images
+    - kubectl get pods --all-namespaces
+    - helm install --version $TAG -n end2end-test --set image.pullPolicy=IfNotPresent --set image.tag=$TAG charts/workflow-controller
+    - while [ $(kubectl get pod --selector=app=workflow-controller --all-namespaces | grep 'workflow-controller' | awk '{print $4}') != "Running" ]; do echo "$(kubectl get pod --selector=app=workflow-controller --all-namespaces)"; sleep 5; done
+    - cd ./test/e2e && go test -c && ./e2e.test --kubeconfig=$HOME/.kube/config --ginkgo.slowSpecThreshold 30
+    - helm delete end2end-test
+  - stage: release
+    script:
+      - docker login -u "$DOCKER_USERNAME" p "$DOCKER_PASSWORD"
+      - curl -sL https://git.io/goreleaser | bash
+    deploy:
+    - provider: releases
+      api_key:
+        secure: $GITHUB_TOKEN
+      skip_cleanup: true
+      file:
+      - docs/helm-test-$TAG.tgz
+      on:
+        tags: true
+        branches:
+          only:
+          - master
+          - /^v\d+(\.\d+)+$/
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## Next release
+
+- Helm chart delivery in https://sdminonne.github.io/workflow-controller/

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@
 ARTIFACT=workflow-controller
 
 # 0.0 shouldn't clobber any released builds
-TAG = latest
+TAG= latest
 #PREFIX = gcr.io/google_containers/${ARTIFACT}
-PREFIX =  sdminonne/${ARTIFACT}
+PREFIX =  workflowcontroller/${ARTIFACT}
 
 SOURCES := $(shell find $(SOURCEDIR) ! -name "*_test.go" -name '*.go')
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,24 @@ $ kubectl create -f  .../examples/hello_workflow/workflow.yaml
 
 ### in an openshift cluster
 TODO
+
+
+### Developper
+
+#### How to release the workflow-controller
+
+This project is using [goreleaser](https://goreleaser.com/) and an additional script for releasing also the Helm chart.
+
+For starting the delivery, you need to clone this repository, then:
+
+```
+zsh hack/release.sh <version> <remove-git>
+```
+
+a concreate example is: ```zsh hack/release.sh v1.0.1 upstream```
+
+This script will:
+- generates locally the helm chart with the requested version.
+- updates the helm repo index file (```index.yaml```) file with the new release.
+- Adds commits and tag the repository with all change and the requested version.
+- Push changeset and tag to the remote git repository.

--- a/charts/workflow-controller/Chart.yaml
+++ b/charts/workflow-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A simple Kubernetes workflow controller
 name: workflow-controller
-version: 0.1.1
+version: 0.0.0
 keywords:
 - kubernetes
 - workflow

--- a/charts/workflow-controller/templates/_helpers.tpl
+++ b/charts/workflow-controller/templates/_helpers.tpl
@@ -19,7 +19,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a docker images name 
 */}}
 {{- define "docker-image" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name .Values.image.name -}}
 {{- $tag := default .Chart.Version .Values.image.tag -}}
 {{- printf "%s%s/%s:%s" .Values.image.registry .Values.image.account $name $tag -}}
 {{- end -}}

--- a/charts/workflow-controller/values.yaml
+++ b/charts/workflow-controller/values.yaml
@@ -6,9 +6,10 @@ logLevel: 2
 apiGroupName: dag.example.com
 image:
   registry: ""
-  account: "sdminonne"
-  tag: "latest"
   pullPolicy: Always
+  account: "workflowcontroller"
+  name: ""
+  tag: ""
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,0 +1,2 @@
+apiVersion: v1
+entries:

--- a/hack/ci-minikube-install.sh
+++ b/hack/ci-minikube-install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+
+# Taken from https://github.com/aaron-prindle/minikube-travis-example/blob/master/minikube-ci-initialize.sh
+# Thanks to https://github.com/aaron-prindle
+#
+# Copyright 2017 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+export MINIKUBE_WANTUPDATENOTIFICATION=false
+export MINIKUBE_WANTREPORTERRORPROMPT=false
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+mkdir $HOME/.kube &> /dev/null || true
+touch $HOME/.kube/config
+
+minikube config set WantReportErrorPrompt false
+export KUBECONFIG=$HOME/.kube/config
+sudo -E minikube start --vm-driver=none --extra-config=apiserver.InsecureServingOptions.BindAddress="127.0.0.1" --extra-config=apiserver.InsecureServingOptions.BindPort="8080"  --extra-config=apiserver.Authorization.Mode=RBAC
+
+# this for loop waits until kubectl can access the api server that minikube has created
+KUBECTL_UP="false"
+# Waiting for 5 minutes
+WAIT_UNTIL=$((SECONDS + 600))
+while [ $SECONDS -lt ${WAIT_UNTIL} ]; do
+    kubectl get po &> /dev/null
+    if [ $? -ne 1 ]; then
+      KUBECTL_UP="true"
+      break
+    fi
+    echo -n '.'
+    sleep 2
+done
+if [ "$KUBECTL_UP" != "true" ]; then
+    echo "INIT FAILURE: kubectl could not reach api-server in allotted time"
+    exit 1
+fi
+# kubectl commands are now able to interact with minikube cluster
+
+# OPTIONAL depending on kube-dns requirement
+# this for loop waits until the kubernetes addons are active
+KUBE_ADDONS_UP="false"
+for i in {1..150} # timeout for 5 minutes
+do
+    # Here we are making sure that kubectl is returning the addon pods for the namespace kube-system
+    # Without this check, the second if statement won't be in the proper state for execution
+    if [[ $(kubectl get po -n kube-system -l k8s-app=kube-dns | tail -n +2 | grep "kube-dns") ]]; then
+        # Here we are taking the checking the number of running pods for the namespace kube-system
+        # and making sure that the value on each side of the '/' is equal (ex: 3/3 pods running)
+        # this is necessary to ensure that all addons have come up
+        if [[ ! $(kubectl get po -n kube-system | tail -n +2 | awk '{print $2}' | grep -wEv '^([1-9]+)\/\1$') ]]; then
+            echo "INIT SUCCESS: all kubernetes addons pods are up and running"
+            KUBE_ADDONS_UP="true"
+            break
+        fi
+    fi
+    echo "$(kubectl get po -n kube-system)"
+    sleep 2
+done
+if [ "$KUBE_ADDONS_UP" != "true" ]; then
+    echo "INIT FAILURE: kubernetes addons did not come up in allotted time"
+    # exit 1
+fi
+# kube-addons is available for cluster services

--- a/hack/helm-release.sh
+++ b/hack/helm-release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "please provide the version as parameter: ./helm-release.sh <version>\n"
+    exit 1
+fi
+
+cd $(git rev-parse --show-toplevel)
+helm package --version "$1" charts/workflow-controller
+mv "helm-test-$1.tgz" docs/
+helm repo index docs --url https://sdminonne.github.io/workflow-controller/ --merge docs/index.yaml
+git add --all docs/

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+
+if [ -z "$1" ]; then
+    echo "please provide the version as parameter: ./release.sh <version>\n"
+    exit 1
+fi
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+GIT_REMOTE="origin"
+if [ -n "$2" ]; then
+    GIT_REMOTE=$2
+fi
+
+zsh $GIT_ROOT/hack/helm-release.sh $1
+
+# Update CHANGELOG.md file
+ssed -i.bak "5i## Release $1\n" CHANGELOG.md
+
+git commit -am "release $1"
+git tag -f $1
+git push -f --tags $GIT_REMOTE master


### PR DESCRIPTION
Fixes: #25

This project is using [goreleaser](https://goreleaser.com/) and an additional script for releasing also the Helm chart.

For starting the delivery, you need to clone this repository, then:

```
zsh hack/release.sh <version> <remove-git>
```

a concreate example is: ```zsh hack/release.sh v1.0.1 upstream```

This script will:
- generates locally the helm chart with the requested version.
- updates the helm repo index file (```index.yaml```) file with the new release.
- Adds commits and tag the repository with all change and the requested version.
- Push changeset and tag to the remote git repository.